### PR TITLE
Add support for three character operators

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -156,6 +156,7 @@ export class Formatter {
         while (pos < text.length) {
             let char = text.charAt(pos);
             let next = text.charAt(pos + 1);
+            let third = text.charAt(pos + 2);
 
             let currTokenType: TokenType;
 
@@ -185,10 +186,9 @@ export class Formatter {
             } else if (char === '=' && next === '>') {
                 currTokenType = TokenType.Arrow;
                 nextSeek = 2;
-            } else if (char === '=' && next === '=') {
-                currTokenType = TokenType.Word;
-                nextSeek = 2;
             } else if (
+                // Currently we support only known operators,
+                // formatters will not work for unknown operators, we should find a way to support all operators. 
                 // Math operators
                 (char === '+' ||
                     char === '-' ||
@@ -201,11 +201,13 @@ export class Formatter {
                     char === '^' || // FIXME: Find a way to work with the `<<` and `>>` bitwise operators
                     // Other operators
                     char === '.' ||
-                    char === ':') &&
+                    char === ':' ||
+                    char === '!' ||
+                    char === '=' ) &&
                 next === '='
             ) {
                 currTokenType = TokenType.Assignment;
-                nextSeek = 2;
+                nextSeek = third === '=' ? 3 : 2;
             } else if (char === '=' && next !== '=') {
                 currTokenType = TokenType.Assignment;
             } else if (char === ':' && next === ':') {

--- a/src/test/data/testcase.txt
+++ b/src/test/data/testcase.txt
@@ -24,3 +24,25 @@ $data = [
   self::LAUNCHAAA  => 'test',
   self::WAIT   => 'testtas',
 ];
+
+var abc == 123;
+var fsdafsf == 32423,
+fasdf != 1231321;
+
+var abc === 123;
+var fsdafsf === 32423,
+fasdf !== 1231321;
+
+public function index()
+{
+    $x = 'test';
+    if (
+        $x === 'nott test'
+        || $x === 0
+        || $x !== 'test'
+    ) {
+        return false;
+    } else {
+        return true;
+    }
+}

--- a/src/test/suite/formatter.test.ts
+++ b/src/test/suite/formatter.test.ts
@@ -23,7 +23,11 @@ suite('Formatter Test Suite', () => {
         const formatter = new FakeFormatter();
         const ranges = formatter.getLineRanges(editor);
         const actual = formatter.format(ranges[0]);
-        const expect = ['var abc     = 123;', 'var fsdafsf = 32423,', '    fasdf   = 1231321;'];
+        const expect = [
+            'var abc     = 123;', 
+            'var fsdafsf = 32423,', 
+            '    fasdf   = 1231321;'
+        ];
         assert.deepEqual(actual, expect);
     });
 
@@ -48,6 +52,45 @@ suite('Formatter Test Suite', () => {
         const expect = [
             'test    := 1',
             'teastas := 2',
+        ];
+        assert.deepEqual(actual, expect);
+    });
+
+    test('Formatter::should format assignment like == and !=', () => {
+        editor.selection = new vscode.Selection(29, 0, 29, 0);
+        const formatter = new FakeFormatter();
+        const ranges = formatter.getLineRanges(editor);
+        const actual = formatter.format(ranges[0]);
+        const expect = [
+            'var abc     == 123;', 
+            'var fsdafsf == 32423,', 
+            '    fasdf   != 1231321;'
+        ];
+        assert.deepEqual(actual, expect);
+    });
+
+    test('Formatter::should format assignment like === and !==', () => {
+        editor.selection = new vscode.Selection(33, 0, 33, 0);
+        const formatter = new FakeFormatter();
+        const ranges = formatter.getLineRanges(editor);
+        const actual = formatter.format(ranges[0]);
+        const expect = [
+            'var abc     === 123;', 
+            'var fsdafsf === 32423,', 
+            '    fasdf   !== 1231321;'
+        ];
+        assert.deepEqual(actual, expect);
+    });
+
+    test('Formatter::should format assignment like === and !== with special character', () => {
+        editor.selection = new vscode.Selection(41, 0, 41, 0);
+        const formatter = new FakeFormatter();
+        const ranges = formatter.getLineRanges(editor);
+        const actual = formatter.format(ranges[0]);
+        const expect = [
+            `           $x === 'nott test'`, 
+            '        || $x === 0', 
+            `        || $x !== 'test'`
         ];
         assert.deepEqual(actual, expect);
     });


### PR DESCRIPTION
This patch add support for three character operators, so we can align with  operators like `!==` and `===`.


Address #59 #44