### PR TITLE
Fix alignment with double slash comment

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -237,7 +237,8 @@ export class Formatter {
                 if (
                     lastTokenType === TokenType.Assignment ||
                     lastTokenType === TokenType.Colon ||
-                    lastTokenType === TokenType.Arrow
+                    lastTokenType === TokenType.Arrow ||
+                    lastTokenType === TokenType.Comment
                 ) {
                     if (lt.sgfntTokens.indexOf(lastTokenType) === -1) {
                         lt.sgfntTokens.push(lastTokenType);
@@ -672,7 +673,12 @@ export class Formatter {
                     if (i < info.tokens.length - 1) {
                         res += padding + ' '; // Ensure there's one space after comma.
                     }
-                } else {
+                // Skip if there is only comment type without any operators.
+                } else if(info.tokens.length === 1 && info.tokens[0].type === TokenType.Comment){
+                    exceed++;
+                    break;
+                 }
+                else {
                     if (configSTT[0] < 0) {
                         // operator will stick with the leftside word
                         if (configSTT[1] < 0) {

--- a/src/test/data/testcase.txt
+++ b/src/test/data/testcase.txt
@@ -51,3 +51,12 @@ $item["venue_id"] = $venue->id;
 $item["account_id"] = $venue->parent_id;
 $item["expire_date"] = Carbon::now()->{$carbon_function}();
 $acc_license_data[] = $item;
+
+class MyClass {
+  public:
+    int myNum;  // Attribute (int variable)
+    string myString; // Attribute (string variable)
+};
+
+test := 1        // Only some comments
+teastas := 2 // Only some comments

--- a/src/test/suite/formatter.test.ts
+++ b/src/test/suite/formatter.test.ts
@@ -18,6 +18,22 @@ suite('Formatter Test Suite', () => {
     if (!editor) {
         return;
     }
+
+    test('Formatter::should format comment', () => {
+        editor.selection = new vscode.Selection(0, 0, 0, 0);
+        const formatter = new FakeFormatter();
+        const ranges = formatter.getLineRanges(editor);
+        const actual = formatter.format(ranges[0]);
+        const expect = [
+            '  // Only some comments',
+            '  // Only some comments',
+            '  // Only some comments',
+            '  // Only some comments',
+            '  // Only some comments',
+        ];
+        assert.deepEqual(actual, expect);
+    });
+
     test('Formatter::should format assignment like =', () => {
         editor.selection = new vscode.Selection(6, 0, 6, 0);
         const formatter = new FakeFormatter();
@@ -117,6 +133,30 @@ suite('Formatter Test Suite', () => {
             '$item["account_id"]  = $venue->parent_id;',
             '$item["expire_date"] = Carbon::now()->{$carbon_function}();',
             '$acc_license_data[]  = $item;',
+        ];
+        assert.deepEqual(actual, expect);
+    });
+
+    test('Formatter::should format comment with words', () => {
+        editor.selection = new vscode.Selection(57, 0, 57, 0);
+        const formatter = new FakeFormatter();
+        const ranges = formatter.getLineRanges(editor);
+        const actual = formatter.format(ranges[0]);
+        const expect = [
+            '    int    myNum;     // Attribute (int variable)',
+            '    string myString;  // Attribute (string variable)'
+        ];
+        assert.deepEqual(actual, expect);
+    });
+
+    test('Formatter::should format comment with operators', () => {
+        editor.selection = new vscode.Selection(61, 0, 61, 0);
+        const formatter = new FakeFormatter();
+        const ranges = formatter.getLineRanges(editor);
+        const actual = formatter.format(ranges[0]);
+        const expect = [
+            'test    := 1  // Only some comments',
+            'teastas := 2  // Only some comments'
         ];
         assert.deepEqual(actual, expect);
     });


### PR DESCRIPTION
This patch fix wrong alignment with comment.

Address #58 