### PR TITLE
docs(cursor): add Cursor rules and set them to opt-in (alwaysApply=fa…

### DIFF
--- a/.cursor/rules/build-and-test.mdc
+++ b/.cursor/rules/build-and-test.mdc
@@ -1,0 +1,22 @@
+---
+description: Build and test guidance for the VS Code extension
+alwaysApply: false
+---
+## Build and Test Guidance
+
+- **Install**: `npm ci`
+- **Build**:
+  - Dev: `npm run compile` (bundles `src` to `dist`, then web build)
+  - Watch: `npm run watch`
+  - Package: `npm run package` (production + hidden source maps)
+- **Lint**: `npm run lint` (eslint on `src` `*.ts`)
+- **Tests**:
+  - Compile tests: `npm run compile-tests`
+  - Run: `npm test` (executes [out/test/runTest.js](mdc:out/test/runTest.js))
+  - Test suites: [src/test/suite/](mdc:src/test/suite/)
+- **Debugging**:
+  - Use VS Code Extension Host to run and debug `Align` command `vscode-better-align.align`
+- **Do not edit generated files**: [dist/](mdc:dist/) and [out/](mdc:out/) are build outputs
+- **Web extension**:
+  - Browser entry: [dist/web/extension.js](mdc:dist/web/extension.js)
+  - Build via `npm run compile-web`

--- a/.cursor/rules/project-structure.mdc
+++ b/.cursor/rules/project-structure.mdc
@@ -1,0 +1,25 @@
+---
+alwaysApply: false
+---
+## VS Code Extension Project Structure
+
+- **Entry points**:
+  - `main`: [dist/extension.js](mdc:dist/extension.js) built from [src/extension.ts](mdc:src/extension.ts)
+  - `browser`: [dist/web/extension.js](mdc:dist/web/extension.js)
+- **Core modules**:
+  - Formatter logic: [src/formatter.ts](mdc:src/formatter.ts)
+  - Telemetry: [src/telemetry.ts](mdc:src/telemetry.ts)
+- **Build output**: [dist/](mdc:dist/) and [out/](mdc:out/)
+- **Commands**: `vscode-better-align.align` registered in `package.json`
+- **Activation**: `onStartupFinished` and on command
+- **Configuration**: `betterAlign.*` contributed in [package.json](mdc:package.json)
+- **Scripts** (from `package.json`):
+  - `compile`: webpack bundles + web build
+  - `watch`: webpack watch
+  - `package`: prod bundle + hidden source maps
+  - `lint`: eslint on `src` `*.ts`
+  - `test`: VS Code tests via [out/test/runTest.js](mdc:out/test/runTest.js)
+
+Notes
+- Source TypeScript lives in [src/](mdc:src/); do not edit built files under [dist/](mdc:dist/) or [out/](mdc:out/).
+- Images and marketplace metadata in [images/](mdc:images/) and [README.md](mdc:README.md).

--- a/.cursor/rules/typescript-style.mdc
+++ b/.cursor/rules/typescript-style.mdc
@@ -1,0 +1,28 @@
+---
+alwaysApply: false
+---
+## TypeScript Conventions for this repo
+
+- **Target**: match `@types/vscode` `^1.47.0` API, Node `18.x` types
+- **Imports**: prefer direct VS Code API imports `import * as vscode from 'vscode'`
+- **Types**:
+  - Explicit function return types for exported APIs
+  - Avoid `any`; model narrow types where practical
+- **Control flow**:
+  - Prefer early returns, shallow nesting
+  - Handle errors meaningfully; avoid empty `catch`
+- **Formatting**:
+  - Follow existing style; keep lines readable, wrap long expressions
+  - Use multi-line constructs instead of dense one-liners
+- **Naming**:
+  - Functions: verbs; variables: descriptive nouns
+  - Avoid abbreviations and 1–2 letter symbols
+- **Comments**:
+  - Explain intent, not mechanics; keep concise
+- **Build**:
+  - Do not import from `out/` or `dist/` in source
+  - Public surface in `src/extension.ts`; keep web-specific code under `dist/web`
+- **Tests**:
+  - Place under `src/test/suite/`; avoid coupling to build artifacts
+- **Telemetry**:
+  - Use utilities in [src/telemetry.ts](mdc:src/telemetry.ts); respect user privacy and VS Code guidelines


### PR DESCRIPTION
…lse)\n\n- project-structure.mdc: switched to on-demand\n- typescript-style.mdc: switched to on-demand\n- build-and-test.mdc: ensured metadata and on-demand status\n\nThese rules help AI navigate project structure, TS style, and build/test without auto-applying to unrelated contexts.